### PR TITLE
fix: mobile menu navigation and onClose fixes

### DIFF
--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { NavLink } from "react-router";
+import { NavLink, useNavigate } from "react-router";
 import { gsap } from "gsap";
 import { ScrollToPlugin } from "gsap/ScrollToPlugin";
 import { useSmoothScrollContext } from "../context/SmoothScrollProvider";
@@ -41,17 +41,18 @@ function MobileNav({
 }: MobileNavProps) {
   // NEW
   const menuRef = useRef<HTMLDivElement>(null);
-  const firstLinkRef = useRef<HTMLButtonElement>(null);
+  // const firstLinkRef = useRef<HTMLButtonElement>(null);
+  const navigate = useNavigate();
   const { scrollToSection, activeSection, isHomePage } =
     useSmoothScrollContext();
   const vh = useViewportHeight();
 
   // Focus management for accessibility
-  useEffect(() => {
-    if (isMenuOpen && firstLinkRef.current) {
-      firstLinkRef.current.focus();
-    }
-  }, [isMenuOpen]);
+  // useEffect(() => {
+  //   if (isMenuOpen && firstLinkRef.current) {
+  //     firstLinkRef.current.focus();
+  //   }
+  // }, [isMenuOpen]);
 
   // iOS-specific body scroll lock
   useEffect(() => {
@@ -101,7 +102,7 @@ function MobileNav({
       return;
     }
 
-    // navigate("/", { state: { scrollTo: url }, replace: true });
+    navigate("/", { state: { scrollTo: url }, replace: true });
   };
 
   const routeLinks = navLinks.filter((link) => link.type === "route");
@@ -124,7 +125,10 @@ function MobileNav({
           >
             <div className="flex justify-between items-start">
               <img
-                onClick={() => handleScrollLink("home")}
+                onClick={() => {
+                  setIsMenuOpen(false);
+                  handleScrollLink("home");
+                }}
                 src={safulpayTextIcon}
                 alt={`${companyName} text logo`}
                 className="h-42.5 px-3.25 py-1.25 cursor-pointer max-md:h-auto"
@@ -140,7 +144,10 @@ function MobileNav({
                 style={{
                   display: vh > 680 ? "none" : "",
                 }}
-                onClick={() => handleScrollLink("home")}
+                onClick={() => {
+                  setIsMenuOpen(false);
+                  handleScrollLink("home");
+                }}
               >
                 <img
                   src={safulPayLogo}
@@ -175,9 +182,9 @@ function MobileNav({
               role="menu"
               className="flex flex-col items-start mb-0 m:mb-11.25 "
             >
-              {scrollLinks.map((link, index) => (
+              {scrollLinks.map((link) => (
                 <button
-                  ref={index === 0 ? firstLinkRef : null}
+                  // ref={index === 0 ? firstLinkRef : null}
                   key={`mobile-scroll-${link.url}`}
                   onClick={() => handleScrollLink(link.url)}
                   role="menuitem"


### PR DESCRIPTION
# **Description**
<!--- Describe your changes in detail -->
This PR fixes issue of mobile menu not closing onClick of SafulPay logo, and section routing to homepages when not in homepage


## **What did you do?**
- Fix mobile menu to close onClick of SafulPay logo
- Fix navigation back to HomePage when not in homepage and theres a click on a homepage section link



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (changes that do not relate to a fix or feature and don't modify src or test files)

# **Check List**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR are clear and explain the approach.
- [x] I am making a pull request against the **main branch**
- [x] My commit message style matches our requested structure.
- [x] My code additions will not fail code linting checks or unit tests.
- [x] I am only making changes to files I was requested to.

---
# Images
- Linting check (npm run lint) and build check(npm run build)
<img width="1160" alt="Screenshot 2025-04-30 at 16 47 42" src="https://github.com/user-attachments/assets/964898a7-25d1-4c42-a34c-a75b07a84799" />



