### PR TITLE
feat(seo): full SEO, AEO and structured data implementation

### DIFF
--- a/src/app/(app)/about-us/page.tsx
+++ b/src/app/(app)/about-us/page.tsx
@@ -1,10 +1,46 @@
+import type { Metadata } from "next";
+import { companyData } from "@/data/companyData";
 import About from "@/components/sections/About";
 import Team from "@/components/sections/Team";
 import Download from "@/components/sections/Download";
+import JsonLd from "@/components/JsonLd";
+
+const { company, seo, socials, team } = companyData;
+
+export const metadata: Metadata = {
+  title: `About ${company.name}`,
+  description: `Learn about ${company.name} — ${company.description} Meet the team behind Sierra Leone's leading mobile money platform.`,
+  alternates: { canonical: `${seo.siteUrl}/about-us` },
+  openGraph: {
+    title: `About ${company.name}`,
+    description: `Meet the team and learn the mission behind ${company.name} — Sierra Leone's leading mobile money platform.`,
+    url: `${seo.siteUrl}/about-us`,
+  },
+};
+
+const aboutPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "AboutPage",
+  name: `About ${company.name}`,
+  url: `${seo.siteUrl}/about-us`,
+  description: company.description,
+  mainEntity: {
+    "@type": "Organization",
+    name: company.name,
+    url: seo.siteUrl,
+    sameAs: socials.map((s) => s.url),
+    employee: team.members.map((m) => ({
+      "@type": "Person",
+      name: m.name,
+      jobTitle: m.role,
+    })),
+  },
+};
 
 export default function AboutUs() {
   return (
     <>
+      <JsonLd data={aboutPageSchema} />
       <main className="py-75 gap-75 max-md:gap-25 max-md:pt-36">
         <About />
         <Team />

--- a/src/app/(app)/download/page.tsx
+++ b/src/app/(app)/download/page.tsx
@@ -1,10 +1,41 @@
+import type { Metadata } from "next";
+import { companyData } from "@/data/companyData";
 import Download from "@/components/sections/Download";
+import JsonLd from "@/components/JsonLd";
+
+const { company, seo, downloads } = companyData;
+
+export const metadata: Metadata = {
+  title: `Download ${company.name}`,
+  description: `Download the ${company.name} app for iOS and Android. Sierra Leone's fastest mobile money app — send money, pay bills, and top up airtime in seconds.`,
+  alternates: { canonical: `${seo.siteUrl}/download` },
+  openGraph: {
+    title: `Download ${company.name}`,
+    description: `Get the ${company.name} app on the App Store or Google Play. Available for iOS and Android.`,
+    url: `${seo.siteUrl}/download`,
+  },
+};
+
+const downloadSchema = {
+  "@context": "https://schema.org",
+  "@type": "MobileApplication",
+  name: company.name,
+  operatingSystem: "iOS, Android",
+  applicationCategory: "FinanceApplication",
+  description: seo.fullDescription,
+  downloadUrl: [downloads.appStore.link, downloads.playStore.link],
+  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+  author: { "@type": "Organization", name: company.name, url: seo.siteUrl },
+};
 
 export default function DownloadPage() {
   return (
-    <main className="bg-text-color flex flex-col">
-      <Download />
-      <div className="h-50 bg-white w-full" />
-    </main>
+    <>
+      <JsonLd data={downloadSchema} />
+      <main className="bg-text-color flex flex-col">
+        <Download />
+        <div className="h-50 bg-white w-full" />
+      </main>
+    </>
   );
 }

--- a/src/app/(app)/platform/page.tsx
+++ b/src/app/(app)/platform/page.tsx
@@ -1,39 +1,76 @@
 import type { Metadata } from "next";
+import { companyData } from "@/data/companyData";
 import PlatformHero from "@/components/sections/platform/PlatformHero";
 import AgencySection from "@/components/sections/platform/AgencySection";
 import MerchantSection from "@/components/sections/platform/MerchantSection";
 import DeveloperSection from "@/components/sections/platform/DeveloperSection";
 import PlatformCTA from "@/components/sections/platform/PlatformCTA";
+import JsonLd from "@/components/JsonLd";
+
+const { company, seo } = companyData;
 
 export const metadata: Metadata = {
-  title: "SafulPay Platform | For Agents, Merchants & Developers",
+  title: `${company.name} Platform | For Agents, Merchants & Developers`,
   description:
     "One infrastructure layer. Three purpose-built products. Agency management, merchant payments, and developer APIs — all on the SafulPay platform.",
+  alternates: { canonical: `${seo.siteUrl}/platform` },
+  openGraph: {
+    title: `${company.name} Platform | For Agents, Merchants & Developers`,
+    description:
+      "Agency banking, merchant payment tools, and REST APIs for developers — all built on SafulPay's infrastructure in Sierra Leone.",
+    url: `${seo.siteUrl}/platform`,
+  },
+};
+
+const platformSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  name: `${company.name} Platform`,
+  url: `${seo.siteUrl}/platform`,
+  description:
+    "One infrastructure layer. Three purpose-built products. Agency management, merchant payments, and developer APIs.",
+  mainEntity: [
+    {
+      "@type": "Service",
+      name: "Agency Banking Platform",
+      description:
+        "Offer cash-in, cash-out, bill payments and remittance pickup. Earn transparent commission on every transaction.",
+      provider: { "@type": "Organization", name: company.name },
+    },
+    {
+      "@type": "Service",
+      name: "Merchant Payment Tools",
+      description:
+        "Receive QR, link and in-app payments. Pay salaries and suppliers in bulk.",
+      provider: { "@type": "Organization", name: company.name },
+    },
+    {
+      "@type": "Service",
+      name: "Developer API",
+      description:
+        "A single REST API for mobile money, banks, bills and remittances across Sierra Leone. Sandbox, webhooks, idempotency — built right.",
+      provider: { "@type": "Organization", name: company.name },
+    },
+  ],
 };
 
 export default function PlatformPage() {
   return (
-    <main className="pt-0 gap-0">
-      {/* Hero — dark green background */}
-      <div className="w-full bg-primary-color">
-        <PlatformHero />
-      </div>
-
-      {/* Agency — white */}
-      <AgencySection />
-
-      {/* Merchant — subtle off-white */}
-      <div className="w-full bg-zinc-50">
-        <MerchantSection />
-      </div>
-
-      {/* Developer — dark green */}
-      <div className="w-full bg-primary-color">
-        <DeveloperSection />
-      </div>
-
-      {/* CTA — white */}
-      <PlatformCTA />
-    </main>
+    <>
+      <JsonLd data={platformSchema} />
+      <main className="pt-0 gap-0">
+        <div className="w-full bg-primary-color">
+          <PlatformHero />
+        </div>
+        <AgencySection />
+        <div className="w-full bg-zinc-50">
+          <MerchantSection />
+        </div>
+        <div className="w-full bg-primary-color">
+          <DeveloperSection />
+        </div>
+        <PlatformCTA />
+      </main>
+    </>
   );
 }

--- a/src/app/(app)/privacy/page.tsx
+++ b/src/app/(app)/privacy/page.tsx
@@ -1,10 +1,17 @@
+import type { Metadata } from "next";
+import { companyData } from "@/data/companyData";
 import { privacyPolicyData } from "@/data/agreementData";
 import Agreement from "@/components/Agreement";
 
+const { company, seo } = companyData;
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description: `Read the ${company.name} Privacy Policy to understand how we collect, use, and protect your personal data and financial information.`,
+  alternates: { canonical: `${seo.siteUrl}/privacy` },
+  robots: { index: true, follow: true },
+};
+
 export default function PrivacyPolicy() {
-  return (
-    <>
-      <Agreement data={privacyPolicyData} />
-    </>
-  );
+  return <Agreement data={privacyPolicyData} />;
 }

--- a/src/app/(app)/terms-and-condition/page.tsx
+++ b/src/app/(app)/terms-and-condition/page.tsx
@@ -1,10 +1,17 @@
-import Agreement from "@/components/Agreement";
+import type { Metadata } from "next";
+import { companyData } from "@/data/companyData";
 import { termsAndConditionsData } from "@/data/agreementData";
+import Agreement from "@/components/Agreement";
+
+const { company, seo } = companyData;
+
+export const metadata: Metadata = {
+  title: "Terms & Conditions",
+  description: `Read the ${company.name} Terms and Conditions governing use of our mobile money platform, services, and APIs.`,
+  alternates: { canonical: `${seo.siteUrl}/terms-and-condition` },
+  robots: { index: true, follow: true },
+};
 
 export default function TermsCondition() {
-  return (
-    <>
-      <Agreement data={termsAndConditionsData} />
-    </>
-  );
+  return <Agreement data={termsAndConditionsData} />;
 }

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useRef } from "react";
+import { useViewportHeight } from "@/hooks/useViewportHeight";
+import { useScaleFadeIn } from "@/hooks/animations/useScaleFadeIn";
+import NavBar from "@/components/sections/NavBar";
+import Hero from "@/components/sections/Hero";
+import Features from "@/components/sections/Features";
+import MoreFeatures from "@/components/sections/MoreFeatures";
+import Security from "@/components/sections/Security";
+import Works from "@/components/sections/Works";
+import Testimonial from "@/components/sections/Testimonial";
+import Partners from "@/components/Partners";
+import Download from "@/components/sections/Download";
+import Faqs from "@/components/sections/Faqs";
+import MainFooter from "@/components/sections/MainFooter";
+import SolutionsPreview from "@/components/sections/SolutionsPreview";
+
+export default function HomeClient() {
+  const mainRef = useRef<HTMLDivElement | null>(null);
+  const vh = useViewportHeight();
+
+  useScaleFadeIn({
+    containerRef: mainRef,
+    fromScaleX: 0.8,
+    fromOpacity: 1,
+    scrub: 0.5,
+    end: "top top",
+  });
+
+  return (
+    <div className="relative">
+      <NavBar />
+      <Hero />
+
+      <div
+        className={`absolute ${
+          vh < 620 ? "top-[50%]" : "top-[80vh]"
+        } w-screen bg-transparent overflow-auto`}
+      >
+        <div className="h-32 md:h-30 sticky"></div>
+        <main ref={mainRef} className="relative rounded-t-[40px] max-m:pt-15">
+          <Features />
+          <MoreFeatures />
+          <Security />
+          <SolutionsPreview />
+          <Works />
+          <Testimonial />
+          <div className="absolute top-4/15 flex gap-2.5 whitespace-nowrap bg-primary-color rotate-[-8.29deg] w-max z-9 max-md:hidden">
+            <Partners />
+          </div>
+          <Download />
+          <Faqs />
+        </main>
+        <MainFooter />
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,23 +1,85 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Outfit } from "next/font/google";
 import { SmoothScrollProvider } from "../context/SmoothScrollProvider";
+import { companyData } from "@/data/companyData";
 import "../index.css";
 
-const outfit = Outfit({ subsets: ["latin"] });
+const outfit = Outfit({ subsets: ["latin"], display: "swap" });
+
+const { company, seo } = companyData;
 
 export const metadata: Metadata = {
-  title: "SafulPay | Finance just got better",
-  description: "Finance just got better",
+  metadataBase: new URL(seo.siteUrl),
+  title: {
+    default: `${company.name} | ${company.slogan}`,
+    template: `%s | ${company.name}`,
+  },
+  description: seo.fullDescription,
+  keywords: seo.keywords,
+  authors: [{ name: company.name, url: seo.siteUrl }],
+  creator: company.name,
+  publisher: company.name,
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_SL",
+    url: seo.siteUrl,
+    siteName: company.name,
+    title: `${company.name} | ${company.slogan}`,
+    description: seo.shortDescription,
+    images: [
+      {
+        url: seo.ogImagePath,
+        width: 1200,
+        height: 630,
+        alt: `${company.name} — ${company.slogan}`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${company.name} | ${company.slogan}`,
+    description: seo.shortDescription,
+    images: [seo.ogImagePath],
+    creator: seo.twitterHandle,
+    site: seo.twitterHandle,
+  },
   icons: [
+    { rel: "icon", url: "/safulpay-icon.svg", type: "image/svg+xml" },
     {
-      media: "(prefers-color-scheme: light)",
+      rel: "icon",
       url: "/safulpay-icon-green.svg",
+      media: "(prefers-color-scheme: light)",
     },
     {
-      media: "(prefers-color-scheme: dark)",
+      rel: "icon",
       url: "/safulpay-icon-lemon.svg",
+      media: "(prefers-color-scheme: dark)",
     },
+    { rel: "apple-touch-icon", url: seo.appleTouchIconPath },
   ],
+  manifest: "/manifest.webmanifest",
+  alternates: { canonical: seo.siteUrl },
+  category: "finance",
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: seo.themeColor },
+    { media: "(prefers-color-scheme: dark)", color: "#c3f02c" },
+  ],
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from "next";
+import { companyData } from "@/data/companyData";
+
+const { company, seo } = companyData;
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: company.name,
+    short_name: company.name,
+    description: seo.shortDescription,
+    start_url: "/",
+    display: "standalone",
+    background_color: seo.backgroundColor,
+    theme_color: seo.themeColor,
+    categories: ["finance", "utilities"],
+    icons: [
+      {
+        src: "/safulpay-icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "any",
+      },
+      {
+        src: "/safulpay-icon-green.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "maskable",
+      },
+    ],
+  };
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,59 +1,84 @@
-"use client";
+import type { Metadata } from "next";
+import { companyData } from "@/data/companyData";
+import { faqsData } from "@/data/appContent";
+import JsonLd from "@/components/JsonLd";
+import HomeClient from "./HomeClient";
 
-import { useRef } from "react";
-import { useViewportHeight } from "../hooks/useViewportHeight";
-import { useScaleFadeIn } from "../hooks/animations/useScaleFadeIn";
-import NavBar from "@/components/sections/NavBar";
-import Hero from "@/components/sections/Hero";
-import Features from "@/components/sections/Features";
-import MoreFeatures from "@/components/sections/MoreFeatures";
-import Security from "@/components/sections/Security";
-import Works from "@/components/sections/Works";
-import Testimonial from "@/components/sections/Testimonial";
-import Partners from "@/components/Partners";
-import Download from "@/components/sections/Download";
-import Faqs from "@/components/sections/Faqs";
-import MainFooter from "@/components/sections/MainFooter";
-import SolutionsPreview from "@/components/sections/SolutionsPreview";
+const { company, seo, socials, downloads } = companyData;
+
+export const metadata: Metadata = {
+  title: `${company.name} | ${company.slogan}`,
+  description: seo.fullDescription,
+  alternates: { canonical: seo.siteUrl },
+};
+
+const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: company.name,
+  url: seo.siteUrl,
+  logo: `${seo.siteUrl}/safulpay-icon-green.svg`,
+  description: seo.fullDescription,
+  foundingLocation: "Sierra Leone",
+  sameAs: socials.map((s) => s.url),
+  contactPoint: {
+    "@type": "ContactPoint",
+    contactType: "customer support",
+    email: "info@safulpay.com",
+    availableLanguage: "English",
+  },
+};
+
+const webSiteSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: company.name,
+  url: seo.siteUrl,
+  description: seo.shortDescription,
+  potentialAction: {
+    "@type": "SearchAction",
+    target: {
+      "@type": "EntryPoint",
+      urlTemplate: `${seo.siteUrl}/?q={search_term_string}`,
+    },
+    "query-input": "required name=search_term_string",
+  },
+};
+
+const appSchema = {
+  "@context": "https://schema.org",
+  "@type": "MobileApplication",
+  name: company.name,
+  operatingSystem: "iOS, Android",
+  applicationCategory: "FinanceApplication",
+  description: seo.fullDescription,
+  url: seo.siteUrl,
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+  downloadUrl: [downloads.appStore.link, downloads.playStore.link],
+  author: { "@type": "Organization", name: company.name },
+};
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqsData.faqs.map((faq) => ({
+    "@type": "Question",
+    name: faq.question,
+    acceptedAnswer: { "@type": "Answer", text: faq.answer },
+  })),
+};
 
 export default function HomePage() {
-  const mainRef = useRef<HTMLDivElement | null>(null);
-  const vh = useViewportHeight();
-
-  useScaleFadeIn({
-    containerRef: mainRef,
-    fromScaleX: 0.8,
-    fromOpacity: 1,
-    scrub: 0.5,
-    end: "top top",
-  });
-
   return (
-    <div className="relative">
-      <NavBar />
-      <Hero />
-
-      <div
-        className={`absolute ${
-          vh < 620 ? "top-[50%]" : "top-[80vh]"
-        } w-screen bg-transparent overflow-auto`}
-      >
-        <div className="h-32 md:h-30 sticky"></div>
-        <main ref={mainRef} className="relative rounded-t-[40px] max-m:pt-15">
-          <Features />
-          <MoreFeatures />
-          <Security />
-          <SolutionsPreview />
-          <Works />
-          <Testimonial />
-          <div className="absolute top-4/15 flex gap-2.5 whitespace-nowrap bg-primary-color rotate-[-8.29deg] w-max z-9 max-md:hidden">
-            <Partners />
-          </div>
-          <Download />
-          <Faqs />
-        </main>
-        <MainFooter />
-      </div>
-    </div>
+    <>
+      <JsonLd
+        data={[organizationSchema, webSiteSchema, appSchema, faqSchema]}
+      />
+      <HomeClient />
+    </>
   );
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from "next";
+import { companyData } from "@/data/companyData";
+
+export default function robots(): MetadataRoute.Robots {
+  const { siteUrl } = companyData.seo;
+
+  return {
+    rules: [
+      { userAgent: "*", allow: "/", disallow: ["/api/"] },
+      // Explicitly allow major AI crawlers so content appears in AI answers
+      { userAgent: "GPTBot", allow: "/" },
+      { userAgent: "ChatGPT-User", allow: "/" },
+      { userAgent: "ClaudeBot", allow: "/" },
+      { userAgent: "anthropic-ai", allow: "/" },
+      { userAgent: "PerplexityBot", allow: "/" },
+      { userAgent: "Googlebot", allow: "/" },
+      { userAgent: "Bingbot", allow: "/" },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,41 @@
+import type { MetadataRoute } from "next";
+import { companyData } from "@/data/companyData";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const { siteUrl } = companyData.seo;
+  const now = new Date();
+
+  return [
+    { url: siteUrl, lastModified: now, changeFrequency: "weekly", priority: 1 },
+    {
+      url: `${siteUrl}/platform`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
+      url: `${siteUrl}/about-us`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${siteUrl}/download`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${siteUrl}/privacy`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${siteUrl}/terms-and-condition`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+  ];
+}

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,12 @@
+interface JsonLdProps {
+  data: Record<string, unknown> | Record<string, unknown>[];
+}
+
+export default function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/src/data/companyData.ts
+++ b/src/data/companyData.ts
@@ -89,8 +89,21 @@ export interface Team {
   members: Member[];
 }
 
+export interface SeoConfig {
+  siteUrl: string;
+  twitterHandle: string;
+  themeColor: string;
+  backgroundColor: string;
+  shortDescription: string;
+  fullDescription: string;
+  keywords: string[];
+  ogImagePath: string;
+  appleTouchIconPath: string;
+}
+
 export interface SafulPayData {
   company: Company;
+  seo: SeoConfig;
   partners: Partner[];
   regulated: Regulated;
   socials: Social[];
@@ -109,6 +122,31 @@ export const companyData: SafulPayData = {
     slogan: "Finance Just Got Better",
     description:
       "Our mission is to provide seamless and secure mobile money solutions, empowering users to manage their finances with ease.",
+  },
+  seo: {
+    siteUrl: "https://safulpay.com",
+    twitterHandle: "@safulpay",
+    themeColor: "#3a5646",
+    backgroundColor: "#3a5646",
+    shortDescription:
+      "Sierra Leone's leading mobile money platform. Send, receive, pay bills and accept payments — all in one app.",
+    fullDescription:
+      "SafulPay is Sierra Leone's leading mobile money platform — send money, pay bills, top up airtime, and receive international remittances in seconds. Built for users, agents, merchants, and developers.",
+    keywords: [
+      "mobile money",
+      "Sierra Leone",
+      "fintech",
+      "send money",
+      "pay bills",
+      "remittance",
+      "SafulPay",
+      "digital payments",
+      "agency banking",
+      "merchant payments",
+      "developer API",
+    ],
+    ogImagePath: "/og-image.png",
+    appleTouchIconPath: "/apple-touch-icon.png",
   },
   partners: [
     // {
@@ -250,9 +288,9 @@ export const companyData: SafulPayData = {
         name: "Oyinlola Lawal",
         role: "Chief Technology Officer",
         socials: {
-          twitter: "https://twitter.com/janesmith",
-          github: "https://github.com/michaelbrown",
-          linkedin: "https://linkedin.com/in/michaelbrown",
+          twitter: "https://x.com/honeyzrich?s=21&t=C8AmSZA0skcAWJ-gYIUjFg",
+          github: "https://github.com/lawalOyinlola",
+          linkedin: "https://www.linkedin.com/in/lawaloyinlola",
         },
       },
       {


### PR DESCRIPTION
## Summary
- Adds a central `SeoConfig` in `companyData.ts` — single source of truth for
  site URL, descriptions, keywords, theme colors and OG image paths
- Generates `robots.txt` with explicit allow rules for AI crawlers (GPTBot,
  ClaudeBot, PerplexityBot) and `sitemap.xml` covering all 6 routes
- Adds PWA `manifest.webmanifest` and full `Viewport` / Open Graph / Twitter
  Card metadata in the root layout
- Converts the homepage from a client component to a server component
  (`HomeClient.tsx` holds the animations) so Next.js can export page-level
  metadata
- Injects JSON-LD structured data schemas: Organization, WebSite, 
  MobileApplication, FAQPage (homepage), AboutPage (about), Service ×3
  (platform), MobileApplication (download)
- Adds per-page `metadata` with title, description, canonical and OG overrides
  to every route that was missing it

## Test plan
- [ ] `/robots.txt` and `/sitemap.xml` render correctly in browser
- [ ] `/manifest.webmanifest` loads with correct name/colors
- [ ] Homepage `<head>` contains OG, Twitter Card and JSON-LD script tags
- [ ] Each page title follows the `Page | SafulPay` template
- [ ] No TypeScript errors (`pnpm tsc --noEmit`)
