### PR TITLE
feat: add SEO creator attribution, sitemap fix, and Search Console verification

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,7 +10,7 @@ const outfit = Outfit({
   weight: ["200", "300", "400", "500", "600", "700", "900"],
 });
 
-const { company, seo } = companyData;
+const { company, seo, creator } = companyData;
 
 export const metadata: Metadata = {
   metadataBase: new URL(seo.siteUrl),
@@ -20,8 +20,11 @@ export const metadata: Metadata = {
   },
   description: seo.fullDescription,
   keywords: seo.keywords,
-  authors: [{ name: company.name, url: seo.siteUrl }],
-  creator: company.name,
+  authors: [
+    { name: company.name, url: seo.siteUrl },
+    { name: creator.name, url: creator.url },
+  ],
+  creator: `${creator.name} (${creator.role}, ${company.name})`,
   publisher: company.name,
   robots: {
     index: true,
@@ -75,6 +78,9 @@ export const metadata: Metadata = {
   manifest: "/manifest.webmanifest",
   alternates: { canonical: seo.siteUrl },
   category: "finance",
+  verification: {
+    google: "4Ndph0rA1_7wDSnv-NYZ5tQdH8iAGjy3NtAmOAv8mZA",
+  },
 };
 
 export const viewport: Viewport = {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { faqsData } from "@/data/appContent";
 import JsonLd from "@/components/shared/JsonLd";
 import HomeClient from "@/app/HomeClient";
 
-const { company, seo, socials, downloads } = companyData;
+const { company, seo, socials, downloads, creator } = companyData;
 
 export const metadata: Metadata = {
   title: `${company.name} | ${company.slogan}`,
@@ -29,12 +29,25 @@ const organizationSchema = {
   },
 };
 
+const creatorSchema = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "@id": `${seo.siteUrl}/#creator`,
+  name: creator.name,
+  alternateName: creator.shortName,
+  url: creator.url,
+  jobTitle: creator.role,
+  worksFor: { "@type": "Organization", name: company.name, url: seo.siteUrl },
+  sameAs: creator.sameAs,
+};
+
 const webSiteSchema = {
   "@context": "https://schema.org",
   "@type": "WebSite",
   name: company.name,
   url: seo.siteUrl,
   description: seo.shortDescription,
+  creator: { "@id": `${seo.siteUrl}/#creator` },
   potentialAction: {
     "@type": "SearchAction",
     target: {
@@ -80,7 +93,13 @@ export default function HomePage() {
   return (
     <>
       <JsonLd
-        data={[organizationSchema, webSiteSchema, appSchema, faqSchema]}
+        data={[
+          organizationSchema,
+          creatorSchema,
+          webSiteSchema,
+          appSchema,
+          faqSchema,
+        ]}
       />
       <HomeClient />
     </>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -22,6 +22,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.8,
     },
     {
+      url: `${siteUrl}/contact-us`,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
       url: `${siteUrl}/privacy`,
       changeFrequency: "yearly",
       priority: 0.3,

--- a/src/data/companyData.ts
+++ b/src/data/companyData.ts
@@ -105,9 +105,18 @@ export interface SeoConfig {
   };
 }
 
+export interface Creator {
+  name: string;
+  shortName: string;
+  role: string;
+  url: string;
+  sameAs: string[];
+}
+
 export interface SafulPayData {
   company: Company;
   seo: SeoConfig;
+  creator: Creator;
   partners: Partner[];
   regulated: Regulated;
   socials: Social[];
@@ -155,6 +164,20 @@ export const companyData: SafulPayData = {
       default: "/safulpay-icon.svg",
       maskable: "/safulpay-icon-green.svg",
     },
+  },
+  creator: {
+    name: "Oyinlola Lawal",
+    shortName: "LAWAL",
+    role: "Chief Technology Officer",
+    url: "https://www.lawaloyinlola.com",
+    sameAs: [
+      "https://www.lawaloyinlola.com",
+      "https://www.resume.lawaloyinlola.com",
+      "https://www.linkedin.com/in/lawaloyinlola",
+      "https://github.com/lawalOyinlola",
+      "https://x.com/honeyzrich",
+      "https://www.instagram.com/honeyz_rich",
+    ],
   },
   partners: [
     // {


### PR DESCRIPTION
## Summary

- **Creator attribution** — adds `Oyinlola Lawal (CTO)` as a typed `Creator`
  record in `companyData`. Emits a `Person` JSON-LD node on the homepage
  (portfolio, CV, LinkedIn, GitHub, X, Instagram as `sameAs`), wired as the
  `creator` of the `WebSite` schema. Also surfaces in `<meta name="author">`
  and `<meta name="creator">` on every page via `layout.tsx`.

- **Sitemap fix** — `/contact-us` was missing from `sitemap.ts`; all 7 public
  routes are now listed.

- **Search Console verification** — Google verification token added via
  `metadata.verification.google` in `layout.tsx` (no raw HTML tag needed).

## Test plan

- [ ] Deploy to Netlify and confirm build passes
- [ ] Visit `https://safulpay.com/sitemap.xml` — confirm `/contact-us` appears
- [ ] Rich Results Test on `https://safulpay.com` — FAQ, Organization, Software
      Apps still show 3 valid items
- [ ] Schema Markup Validator (`validator.schema.org`) — confirm Person +
      WebSite + creator nodes parse cleanly
- [ ] Google Search Console → Verify → confirm token is detected
